### PR TITLE
Fix using non-standard library name layout

### DIFF
--- a/include/boost/uuid/detail/random_provider_bcrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_bcrypt.ipp
@@ -18,13 +18,12 @@
 #include <boost/throw_exception.hpp>
 
 #if defined(BOOST_UUID_FORCE_AUTO_LINK) || (!defined(BOOST_ALL_NO_LIB) && !defined(BOOST_UUID_RANDOM_PROVIDER_NO_LIB))
-#   define BOOST_LIB_NAME "bcrypt"
-#   if defined(BOOST_AUTO_LINK_NOMANGLE)
-#      include <boost/config/auto_link.hpp>
-#   else
-#      define BOOST_AUTO_LINK_NOMANGLE
-#      include <boost/config/auto_link.hpp>
-#      undef BOOST_AUTO_LINK_NOMANGLE
+#   if defined(BOOST_MSVC) \
+    || defined(__BORLANDC__) \
+    || (defined(__MWERKS__) && defined(_WIN32) && (__MWERKS__ >= 0x3000)) \
+    || (defined(__ICL) && defined(_MSC_EXTENSIONS) && (_MSC_VER >= 1200)) \
+    || (defined(BOOST_CLANG) && defined(BOOST_WINDOWS) && defined(_MSC_VER) && (__clang_major__ >= 4))
+#      pragma comment(lib, "bcrypt.lib")
 #   endif
 #endif
 

--- a/include/boost/uuid/detail/random_provider_wincrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_wincrypt.ipp
@@ -22,17 +22,16 @@
 #include <boost/throw_exception.hpp>
 
 #if defined(BOOST_UUID_FORCE_AUTO_LINK) || (!defined(BOOST_ALL_NO_LIB) && !defined(BOOST_UUID_RANDOM_PROVIDER_NO_LIB))
-#   if defined(_WIN32_WCE)
-#      define BOOST_LIB_NAME "coredll"
-#   else
-#      define BOOST_LIB_NAME "advapi32"
-#   endif
-#   if defined(BOOST_AUTO_LINK_NOMANGLE)
-#      include <boost/config/auto_link.hpp>
-#   else
-#      define BOOST_AUTO_LINK_NOMANGLE
-#      include <boost/config/auto_link.hpp>
-#      undef BOOST_AUTO_LINK_NOMANGLE
+#   if defined(BOOST_MSVC) \
+    || defined(__BORLANDC__) \
+    || (defined(__MWERKS__) && defined(_WIN32) && (__MWERKS__ >= 0x3000)) \
+    || (defined(__ICL) && defined(_MSC_EXTENSIONS) && (_MSC_VER >= 1200)) \
+    || (defined(BOOST_CLANG) && defined(BOOST_WINDOWS) && defined(_MSC_VER) && (__clang_major__ >= 4))
+#      if defined(_WIN32_WCE)
+#         pragma comment(lib, "coredll.lib")
+#      else
+#         pragma comment(lib, "advapi32.lib")
+#      endif
 #   endif
 #endif
 


### PR DESCRIPTION
As `BOOST_AUTO_LINK_NOMANGLE` is checked after `BOOST_AUTO_LINK_TAGGED`
and `BOOST_AUTO_LINK_SYSTEM` in boost/config/auto_link.hpp, using
tagged or system layout would have used the wrong library names for
linking.

This change is based on https://github.com/boostorg/uuid/pull/110, but
adapted to newer changes for clang-cl in
https://github.com/boostorg/config/commit/a18911902dff03f37582696a13bf60768c183c55#diff-e96bc863ddd09e106922c7fbc8f81d1dR103.